### PR TITLE
Resolve Oro 4.1.10 Compatibility Issue

### DIFF
--- a/src/Tracker/AbstractTracker.php
+++ b/src/Tracker/AbstractTracker.php
@@ -31,6 +31,6 @@ abstract class AbstractTracker
      */
     public function getConfigValue(string $name, string $default = null)
     {
-        return $this->configManager->get(Configuration::getConfigKeyByName($name), $default);
+        return $this->configManager->get(Configuration::getConfigKeyByName($name)) ?? $default;
     }
 }


### PR DESCRIPTION
`$default` parameter in `ConfigManager::getCacheKey()` is strict typehinted as a boolean in 4.1.10 onwards.
This release should be backwards compatible with previous versions of Oro 4.X