### PR TITLE
Feature/4.2 compatibility

### DIFF
--- a/src/Tracker/AbstractTracker.php
+++ b/src/Tracker/AbstractTracker.php
@@ -26,10 +26,10 @@ abstract class AbstractTracker
 
     /**
      * @param string $name
-     * @param string $default|null
+     * @param bool $default
      * @return mixed
      */
-    public function getConfigValue(string $name, string $default = null)
+    public function getConfigValue(string $name, $default = false)
     {
         return $this->configManager->get(Configuration::getConfigKeyByName($name), $default);
     }

--- a/src/Tracker/FullStoryTracker.php
+++ b/src/Tracker/FullStoryTracker.php
@@ -33,7 +33,7 @@ class FullStoryTracker extends AbstractTracker
      */
     public function isEnabled(): bool
     {
-        return (bool) $this->getConfigValue(Configuration::FULLSTORY_IS_ENABLED, false);
+        return (bool) $this->getConfigValue(Configuration::FULLSTORY_IS_ENABLED);
     }
 
     /**
@@ -49,7 +49,7 @@ class FullStoryTracker extends AbstractTracker
      */
     public function getDebugEnabled(): bool
     {
-        return (bool) $this->getConfigValue(Configuration::FULLSTORY_DEBUG_ENABLED, false);
+        return (bool) $this->getConfigValue(Configuration::FULLSTORY_DEBUG_ENABLED);
     }
 
     /**
@@ -57,7 +57,7 @@ class FullStoryTracker extends AbstractTracker
      */
     public function getNamespace(): ?string
     {
-        return $this->getConfigValue(Configuration::FULLSTORY_NAMESPACE, self::DEFAULT_NAMESPACE);
+        return $this->getConfigValue(Configuration::FULLSTORY_NAMESPACE) ?? self::DEFAULT_NAMESPACE;
     }
 
     /**


### PR DESCRIPTION
HackOro\CustomerTrackingBundle\Tracker\AbstractTracker::getConfigValue second argument must be a boolean as it is passed to configManager::get which second arg is a boolean. 

It was thought that `$default` was the value that would be returned if no config value was found, however it seems that it is actually a flag on whether it should return the default value of that configuration option.

So, the default value of getConfigValue was updated to be false, and updated any references so the expected behaviour is maintained. 

Updated package was tested with the Log rocket project that was added in the system configs of Oro:
![image](https://user-images.githubusercontent.com/36465099/132282909-c03ee4ef-70bd-408e-b2f2-731e2980bdbe.png)


Tracking code appeared on website after linking the project:
![image](https://user-images.githubusercontent.com/36465099/132282869-f17b7ba0-a989-409e-9a20-dad921a056a6.png)




