### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Inspired by the [OroCommerce Analytics/GTM Bundle](https://github.com/DivanteLtd
 
 Requirements
 -------------------
-* OroCommerce 5.0.X
+* OroCommerce 6.0.X
 
 Installation and Usage
 -------------------

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "OroCommerce Bundle to inject Tracking Code (eg LogRocket, Hotjar, FullStory, etc)",
     "type": "project",
     "require": {
-        "oro/commerce": "5.0.*"
+        "oro/commerce": "6.0.*"
     },
     "autoload": {
         "psr-4": { "HackOro\\CustomerTrackingBundle\\": "./src/" }

--- a/src/DependencyInjection/CompilerPass/TrackerPass.php
+++ b/src/DependencyInjection/CompilerPass/TrackerPass.php
@@ -21,7 +21,7 @@ class TrackerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::REGISTRY_SERVICE)) {
             return;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -33,10 +33,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(HackOroCustomerTrackingExtension::ALIAS);
 
@@ -59,12 +57,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-
-    /**
-     * @param string $key
-     * @return string
-     */
-    public static function getConfigKeyByName($key)
+    public static function getConfigKeyByName(string $key): string
     {
         return implode(ConfigManager::SECTION_MODEL_SEPARATOR, [HackOroCustomerTrackingExtension::ALIAS, $key]);
     }

--- a/src/DependencyInjection/HackOroCustomerTrackingExtension.php
+++ b/src/DependencyInjection/HackOroCustomerTrackingExtension.php
@@ -21,7 +21,7 @@ class HackOroCustomerTrackingExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/HackOroCustomerTrackingBundle.php
+++ b/src/HackOroCustomerTrackingBundle.php
@@ -18,7 +18,7 @@ class HackOroCustomerTrackingBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Layout/DataProvider/CustomerTrackingDataProvider.php
+++ b/src/Layout/DataProvider/CustomerTrackingDataProvider.php
@@ -14,19 +14,14 @@ use HackOro\CustomerTrackingBundle\Tracker\TrackerRegistry;
 
 class CustomerTrackingDataProvider
 {
-    /** @var TrackerRegistry */
-    private $trackerRegistry;
+    private TrackerRegistry $trackerRegistry;
 
     public function __construct(TrackerRegistry $trackerRegistry)
     {
         $this->trackerRegistry = $trackerRegistry;
     }
 
-    /**
-     * @param string $name
-     * @return AbstractTracker|null
-     */
-    public function getTracker(string $name)
+    public function getTracker(string $name): ?AbstractTracker
     {
         return $this->trackerRegistry->getTracker($name);
     }

--- a/src/Tracker/AbstractTracker.php
+++ b/src/Tracker/AbstractTracker.php
@@ -14,8 +14,7 @@ use Oro\Bundle\ConfigBundle\Config\ConfigManager;
 
 abstract class AbstractTracker
 {
-    /** @var ConfigManager */
-    protected $configManager;
+    protected ConfigManager $configManager;
 
     public function __construct(ConfigManager $configManager)
     {
@@ -24,12 +23,7 @@ abstract class AbstractTracker
 
     abstract public function getName() : string;
 
-    /**
-     * @param string $name
-     * @param bool $default
-     * @return mixed
-     */
-    public function getConfigValue(string $name, $default = false)
+    public function getConfigValue(string $name, bool $default = false): mixed
     {
         return $this->configManager->get(Configuration::getConfigKeyByName($name), $default);
     }

--- a/src/Tracker/FullStoryTracker.php
+++ b/src/Tracker/FullStoryTracker.php
@@ -28,41 +28,26 @@ class FullStoryTracker extends AbstractTracker
         return self::NAME;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return (bool) $this->getConfigValue(Configuration::FULLSTORY_IS_ENABLED);
     }
 
-    /**
-     * @return string
-     */
     public function getOrg(): ?string
     {
         return $this->getConfigValue(Configuration::FULLSTORY_ORG);
     }
 
-    /**
-     * @return bool
-     */
     public function getDebugEnabled(): bool
     {
         return (bool) $this->getConfigValue(Configuration::FULLSTORY_DEBUG_ENABLED);
     }
 
-    /**
-     * @return string
-     */
     public function getNamespace(): ?string
     {
         return $this->getConfigValue(Configuration::FULLSTORY_NAMESPACE) ?? self::DEFAULT_NAMESPACE;
     }
 
-    /**
-     * @return string
-     */
     public function getHost(): ?string
     {
         return self::HOST;

--- a/src/Tracker/HotjarTracker.php
+++ b/src/Tracker/HotjarTracker.php
@@ -20,17 +20,11 @@ class HotjarTracker extends AbstractTracker
         return self::NAME;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return (bool) $this->getConfigValue(Configuration::HOTJAR_IS_ENABLED);
     }
 
-    /**
-     * @return string
-     */
     public function getSiteId(): ?string
     {
         return $this->getConfigValue(Configuration::HOTJAR_SITE_ID);

--- a/src/Tracker/LogRocketTracker.php
+++ b/src/Tracker/LogRocketTracker.php
@@ -22,8 +22,6 @@ class LogRocketTracker extends AbstractTracker
 
     /**
      * Is LogRocket enabled?
-     *
-     * @return bool
      */
     public function isEnabled(): bool
     {
@@ -32,8 +30,6 @@ class LogRocketTracker extends AbstractTracker
 
     /**
      * What is the LogRocket APP ID?
-     *
-     * @return string
      */
     public function getAppId(): ?string
     {

--- a/src/Tracker/TrackerRegistry.php
+++ b/src/Tracker/TrackerRegistry.php
@@ -16,14 +16,12 @@ class TrackerRegistry
     /**
      * @var AbstractTracker[]
      */
-    protected $trackers = [];
+    protected array $trackers = [];
 
     /**
      * Add tracker to the registry
-     *
-     * @param AbstractTracker $tracker
      */
-    public function addTracker(AbstractTracker $tracker)
+    public function addTracker(AbstractTracker $tracker): void
     {
         if (array_key_exists($tracker->getName(), $this->trackers)) {
             throw new LogicException(
@@ -37,7 +35,7 @@ class TrackerRegistry
     /**
      * @return AbstractTracker[]
      */
-    public function getTrackers()
+    public function getTrackers(): array
     {
         return $this->trackers;
     }
@@ -45,11 +43,9 @@ class TrackerRegistry
     /**
      * Get tracker by name
      *
-     * @param string $name
-     * @return AbstractTracker
      * @throws LogicException Throw exception when tracker with specified name not found
      */
-    public function getTracker($name)
+    public function getTracker(string $name): AbstractTracker
     {
         if (!array_key_exists($name, $this->trackers)) {
             throw new LogicException(


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Short list of done changes:
- Updated requirements to oro/platform 6.0.*
- Added return types/ type hints
- Deleted not needed annotations
- Added some CS fixes
- Updated README.md